### PR TITLE
Add fail mode option to action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Parameter | Description | Default
 `check-owner` | Whether to check that the root Nixpkgs input has the `NixOS` GitHub org as its owner. | `true`
 `check-supported` | Whether to check that the root Nixpkgs input has a supported Git ref. Currently supported refs: `nixos-22.11`, `nixos-22.11-small`, `nixos-23.05`, `nixos-23.05-small`, `nixos-unstable`, `nixos-unstable-small`, `nixpkgs-22.11-darwin`, `nixpkgs-23.05-darwin`, `nixpkgs-unstable`. | `true`
 `ignore-missing-flake-lock` | Whether to ignore a missing `flake.lock` file, where the path to the file is the value of `flake-lock-path` parameter. If set to `false` (the default is `true`), the Action throws an error and the job fails if the lockfile is missing. | `true`
+`fail-mode` | Fail with an exit code of 1 if any issues are encountered. | `false`
 `send-statistics` | Anonymously report the number of issues detected by the flake checker. This reporting helps measure the effectiveness of the flake checker. Set to `false` to disable. | `true`
 
 Here's an example non-default configuration:
@@ -51,6 +52,7 @@ Here's an example non-default configuration:
     flake-lock-path: ./nix/flake.lock
     check-owner: false
     ignore-missing-flake-lock: false
+    fail-mode: true
 ```
 
 [action]: https://github.com/features/actions

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
       `flake-lock-path` parameter. If set to `false` (the default is `true`), the Action throws
       an error and the job fails if the lockfile is missing.
     default: true
+  fail-mode:
+    description: Fail with an exit code of 1 if any issues are encountered.
+    default: false
   send-statistics:
     description: |
       Anonymously report the number of issues detected by the flake checker. This reporting helps
@@ -66,6 +69,10 @@ runs:
 
           if [ "${{ inputs.ignore-missing-flake-lock }}" == "false" ]; then
             export NIX_FLAKE_CHECKER_IGNORE_MISSING_FLAKE_LOCK="false"
+          fi
+
+          if [ "${{ inputs.fail-mode }}" == "true" ]; then
+            export NIX_FLAKE_CHECKER_FAIL_MODE="true"
           fi
 
           "$RUNNER_TEMP/flake-checker"


### PR DESCRIPTION
Fail mode for the Flake Checker (v0.1.3) isn't yet available via install.determinate.systems but that's okay because this will just be a no-op until then.